### PR TITLE
Improve bad input handling

### DIFF
--- a/lib/vcloud/tools/tester/test_parameters.rb
+++ b/lib/vcloud/tools/tester/test_parameters.rb
@@ -14,11 +14,11 @@ module Vcloud
             raise ArgumentError.new("Missing required file: #{config_file}")
           end
           organization = ENV.fetch('FOG_CREDENTIAL') do
-            raise ArgumentError.new("Must set FOG_CREDENTIAL envvar")
+            raise "Must set FOG_CREDENTIAL envvar"
           end
           all_config = YAML::load(File.open(config_file))
           @input_config = all_config.fetch(organization) do
-            raise ArgumentError.new("Invalid FOG_CREDENTIAL value '#{organization}'")
+            raise "Invalid FOG_CREDENTIAL value '#{organization}'"
           end
         end
 

--- a/spec/vcloud/tools/tester/test_parameters_spec.rb
+++ b/spec/vcloud/tools/tester/test_parameters_spec.rb
@@ -35,14 +35,14 @@ module Vcloud::Tools::Tester
         stub_const('ENV', {})
         expect {
           TestParameters.new("#{@data_dir}/test_minimal_config.yaml")
-        }.to raise_error(ArgumentError, /Must set FOG_CREDENTIAL envvar/)
+        }.to raise_error(RuntimeError, /Must set FOG_CREDENTIAL envvar/)
       end
 
       it "gives a useful error when the FOG_CREDENTIAL is missing from the config" do
         stub_const('ENV', {'FOG_CREDENTIAL' => 'bogus-fog-credential'})
         expect {
           TestParameters.new("#{@data_dir}/test_config.yaml")
-        }.to raise_error(ArgumentError, /Invalid FOG_CREDENTIAL value/)
+        }.to raise_error(RuntimeError, /Invalid FOG_CREDENTIAL value/)
       end
 
       it "gives a useful error when there is no config file" do


### PR DESCRIPTION
I've added cases for the following:
- User does not have FOG_CREDENTIAL set
- User has FOG_CREDENTIAL set to a value not in our config file.

I've also switched the tests to use stub_const(ENV) rather than manipulate the ENV directly -- it is safer and more contained.
