### PR TITLE
Add edge_gateway_id test parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.6 (2014-05-28)
+
+Features:
+
+  - Add edge_gateway_id parameter
+
 ## 0.0.5 (2014-05-23)
 
 Features:

--- a/lib/vcloud/tools/tester/test_parameters.rb
+++ b/lib/vcloud/tools/tester/test_parameters.rb
@@ -86,6 +86,10 @@ module Vcloud
           @input_config["edge_gateway"]
         end
 
+        def edge_gateway_id
+          @input_config["edge_gateway_id"]
+        end
+
         def provider_network
           @input_config["provider_network"]
         end
@@ -97,7 +101,6 @@ module Vcloud
         def provider_network_ip
           @input_config["provider_network_ip"]
         end
-
       end
     end
   end

--- a/lib/vcloud/tools/tester/version.rb
+++ b/lib/vcloud/tools/tester/version.rb
@@ -1,7 +1,7 @@
 module Vcloud
   module Tools
     module Tester
-      VERSION = "0.0.5"
+      VERSION = "0.0.6"
     end
   end
 end


### PR DESCRIPTION
Used the store the value of the edge gateway UUID.

Also, bump the version to 0.0.6 and update the CHANGELOG so that we can
take advantage of the new variables.
