### PR TITLE
[#72424964] Disable `should` syntax in Rspec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'rspec'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/spec/vcloud/tools/tester/test_parameters_spec.rb
+++ b/spec/vcloud/tools/tester/test_parameters_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'vcloud/tools/tester'
 
 module Vcloud::Tools::Tester


### PR DESCRIPTION
`should` syntax is deprecated as of Rspec version 3.0 and the previous
commit converts all of our tests to use `expect` for consistency.

To prevent regressions, this change disables `should` syntax for this
gem.

Also adds a `spec_helper.rb` to accomodate the RSpec configuration,
consistent with the other gems.

---

Please note, we weren't using the `should` syntax anywhere in this gem so there was nothing to convert to use `expect` (as was the case with other gems).
