### PR TITLE
[#73308952] Configure Travis to test Ruby 2.0.0 and 2.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.0.0
+  - 2.1.2
 notifications:
   email: false


### PR DESCRIPTION
To ensure that we support Ruby versions other than 1.9.3.

I've chosen 2.1.2 as it's the latest stable release. 2.0.0 is the
previous stable release.
