### PR TITLE
Depend on vCloud Core 0.6.0; release new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1 (2014-07-14)
+
+Update dependency on vCloud Core to version 0.6.0.
+
 ## 0.1.0 (2014-06-23)
 
 Features:

--- a/lib/vcloud/tools/tester/version.rb
+++ b/lib/vcloud/tools/tester/version.rb
@@ -1,7 +1,7 @@
 module Vcloud
   module Tools
     module Tester
-      VERSION = "0.1.0"
+      VERSION = "0.1.1"
     end
   end
 end

--- a/vcloud-tools-tester.gemspec
+++ b/vcloud-tools-tester.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.23.0'
   spec.add_development_dependency 'simplecov', '~> 0.7.1'
 
-  spec.add_runtime_dependency 'vcloud-core', '~> 0.5.0'
+  spec.add_runtime_dependency 'vcloud-core', '~> 0.6.0'
 end


### PR DESCRIPTION
Bump the dependency on vCloud Core 0.6.0 to avoid dependency issues.
