### PR TITLE
[#74382904] Broaden dependency on vCloud Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2 (2014-07-14)
+
+Make dependency on vCloud Core less restrictive; allow any version in the 0.x series.
+
 ## 0.1.1 (2014-07-14)
 
 Update dependency on vCloud Core to version 0.6.0.

--- a/lib/vcloud/tools/tester/version.rb
+++ b/lib/vcloud/tools/tester/version.rb
@@ -1,7 +1,7 @@
 module Vcloud
   module Tools
     module Tester
-      VERSION = "0.1.1"
+      VERSION = "0.1.2"
     end
   end
 end

--- a/vcloud-tools-tester.gemspec
+++ b/vcloud-tools-tester.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.23.0'
   spec.add_development_dependency 'simplecov', '~> 0.7.1'
 
-  spec.add_runtime_dependency 'vcloud-core', '~> 0.6.0'
+  spec.add_runtime_dependency 'vcloud-core', '~> 0.5'
 end


### PR DESCRIPTION
Loosen the runtime dependency on vCloud Core so that we can use any
version of that gem greater or equal to version 0.5.0 and less than
version 1.0.

This is to break the current deadlock we have between versions due to
this circular dependency (vCloud Core is dependent on vCloud Tools
Tester). We can't release version 0.6.0 of vCloud Core because vCloud
Tools Tester is not yet released and it relies on vCloud Core 0.5.x.
Likewise, we can't release vCloud Tools Tester because it's dependent on
vCloud Core 0.6.
