### PR TITLE
[#74863398] Extract fixture params regardless of class

### DIFF
--- a/lib/vcloud/tools/tester/fixture_parameters.rb
+++ b/lib/vcloud/tools/tester/fixture_parameters.rb
@@ -98,12 +98,11 @@ module Vcloud
           raise "No fixtures present" if @fixtures.empty?
 
           @fixture_params = {}
-          expected_networks = @expected_fixtures_config[:networks]
 
           @fixtures.each do |fixture|
             case fixture
             when ::Fog::Compute::VcloudDirector::Network, Vcloud::Core::OrgVdcNetwork
-              expected_networks.each do |network_ref, expected_network_config|
+              @expected_fixtures_config[:networks].each do |network_ref, expected_network_config|
                 if expected_network_config[:name] == fixture.name
                   @fixture_params["#{network_ref}_id"] = fixture.id
                 end


### PR DESCRIPTION
The `vcloud-tools-tester` Gem create two test networks - one routed, one
isolated. A pre-existing network is of the `Fog::Compute::VcloudDirector::Network`
class, whereas a network that is created by this Gem is of the
`Vcloud::Core::OrgVdcNetwork` class. Both classes will return the ID and the name -
which are the values required for the fixture parameter extraction.

Any time a new network is created by this Gem, the tests fail and complain
that no fixture parameters were received. We can't get the fixture
parameters because we only extract them if they are of one particular class,
not of either.

Ruby allows for case statements to take multiple values in the `when`
statement. If any of these values is true, the script continues. If not, it
errors. Rather than using `or`, the syntax makes use of a comma to specify
multiple values of equal weighting in the `or`. `,` is the equivalent of `||`
in an `if` statement.

The net result of this commit is that we are placing `or` logic in to the
case statement to extract the fixture parameters when the class is either of
the two values specified.
