### PR TITLE
[#68989754] Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0 (2014-08-11)
+
+API changes:
+
+  - Now depends on vCloud Core v0.9, using an API to access fog instead of accessing fog directly.
+
 ## 0.1.3 (2014-07-15)
 
 Bugfixes:

--- a/lib/vcloud/tools/tester/version.rb
+++ b/lib/vcloud/tools/tester/version.rb
@@ -1,7 +1,7 @@
 module Vcloud
   module Tools
     module Tester
-      VERSION = "0.1.3"
+      VERSION = "0.2.0"
     end
   end
 end


### PR DESCRIPTION
This is required because of the circular dependency between vCloud Core and vCloud Tools Tester. In order to remove the temporary fog files that earlier versions of vCloud Tools Tester depended on I need to be able to have vCloud Core depend on a version of vCloud Tools Tester that doesn't require them.
