### PR TITLE
Make error more accurate when organisation is missing from configuration file

### DIFF
--- a/lib/vcloud/tools/tester/user_parameters.rb
+++ b/lib/vcloud/tools/tester/user_parameters.rb
@@ -27,7 +27,7 @@ module Vcloud
           all_config = YAML::load_file(@config_file)
 
           @user_params = all_config.fetch(organization) do
-            raise "Invalid FOG_CREDENTIAL environment variable value '#{organization}'"
+            raise "No matching organisation was found in #{@config_file} for FOG_CREDENTIAL value '#{organization}'"
           end
 
           defined_keys = @user_params.keys

--- a/spec/vcloud/tools/tester/user_parameters_spec.rb
+++ b/spec/vcloud/tools/tester/user_parameters_spec.rb
@@ -33,7 +33,7 @@ describe Vcloud::Tools::Tester::UserParameters do
 
     it "gives a useful error when the FOG_CREDENTIAL is missing from the config" do
       stub_const('ENV', {'FOG_CREDENTIAL' => 'bogus-fog-credential'})
-      expect { parameters }.to raise_error(RuntimeError, /Invalid FOG_CREDENTIAL environment variable value/)
+      expect { parameters }.to raise_error(RuntimeError, /No matching organisation was found in/)
     end
   end
 


### PR DESCRIPTION
This caught me out when an organisation I was testing against was not specified in my vCloud Tools Tester configuration file.

It took me a moment to figure out what the error actually meant, so I've amended it to be more accurate.
