### PR TITLE
Bump version to v0.3.0 in version.rb

### DIFF
--- a/lib/vcloud/tools/tester/version.rb
+++ b/lib/vcloud/tools/tester/version.rb
@@ -1,7 +1,7 @@
 module Vcloud
   module Tools
     module Tester
-      VERSION = "0.2.0"
+      VERSION = "0.3.0"
     end
   end
 end


### PR DESCRIPTION
This was missed when updating the CHANGELOG in #27, and appears to be
the cause of #28.

I'm not 100% this is the only thing that needs to be done to trigger a
publication of the v0.3.0 Gem, let me know if there's anything else that
needs to be done.
