### PR TITLE
Slacken dependency on vcloud-core and Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1 (2015-01-22)
+
+  - Depend on any version of vcloud-core. This is temporary fix so we can release version 1.0.0
+
 ## 0.3.0 (2014-10-06)
 
 Features:

--- a/lib/vcloud/tools/tester/version.rb
+++ b/lib/vcloud/tools/tester/version.rb
@@ -1,7 +1,7 @@
 module Vcloud
   module Tools
     module Tester
-      VERSION = "0.3.0"
+      VERSION = "0.3.1"
     end
   end
 end

--- a/vcloud-tools-tester.gemspec
+++ b/vcloud-tools-tester.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.23.0'
   spec.add_development_dependency 'simplecov', '~> 0.7.1'
 
-  spec.add_runtime_dependency 'vcloud-core', '~> 0.9'
+  spec.add_runtime_dependency 'vcloud-core'
 end


### PR DESCRIPTION
This is so we can release 1.0.0 of vcloud-core which relies on vcloud-tools-tester.