### PR TITLE
Slacken deps for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.2
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ rvm:
   - 2.1.2
 notifications:
   email: false
+sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0 (2016-01-15)
+
+  - Depend on any version of vCloud Core. This is a temporary fix so we can release version 2.0.0
+  - Drop support of Ruby 1.9.3, which is the same as vCloud Core
+
 ## 1.0.0 (2015-01-22)
 
   - Release 1.0.0 since the public API is now stable.

--- a/lib/vcloud/tools/tester/version.rb
+++ b/lib/vcloud/tools/tester/version.rb
@@ -1,7 +1,7 @@
 module Vcloud
   module Tools
     module Tester
-      VERSION = "1.0.0"
+      VERSION = "2.0.0"
     end
   end
 end

--- a/vcloud-tools-tester.gemspec
+++ b/vcloud-tools-tester.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.23.0'
   spec.add_development_dependency 'simplecov', '~> 0.7.1'
 
+  spec.add_runtime_dependency 'fog', '~> 1.36.0'
   spec.add_runtime_dependency 'vcloud-core'
 end

--- a/vcloud-tools-tester.gemspec
+++ b/vcloud-tools-tester.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_development_dependency 'gem_publisher', '1.2.0'
   spec.add_development_dependency 'pry'

--- a/vcloud-tools-tester.gemspec
+++ b/vcloud-tools-tester.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.23.0'
   spec.add_development_dependency 'simplecov', '~> 0.7.1'
 
-  spec.add_runtime_dependency 'vcloud-core', '~> 1.0'
+  spec.add_runtime_dependency 'vcloud-core'
 end


### PR DESCRIPTION
This is the same as [this pull request for the same reason](https://github.com/gds-operations/vcloud-tools-tester/pull/30). 

The dependency of vcloud-tools-tester on a specific vcloud-core version need to be removed so that we can release the new vcloud-core version and allow the tests to pass. Once that is released we can release a further version of vcloud-tools-tester.

I think the tests will fail due to the bug in fog until the new release of vcloud-core has been applied.