### PR TITLE
Add an explicit ruby version to test against.

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,3 +1,5 @@
+export RBENV_VERSION="2.0.0"
+
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
 bundle exec rake


### PR DESCRIPTION
The jenkins job fails to build without knowing which ruby version the
build wants. Explcitly setting it will hopefully stop this.