### PR TITLE
Upgrade to new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.0 (2017-06-22)
+
+  - Upgrade to latest Fog
+  - Drop support for Ruby older than 2.2.2
+  - Add support for Ruby 2.3 and 2.4
+  - Various bugfixes
+
 ## 2.0.0 (2016-01-15)
 
   - Depend on any version of vCloud Core. This is a temporary fix so we can release version 2.0.0

--- a/lib/vcloud/tools/tester/version.rb
+++ b/lib/vcloud/tools/tester/version.rb
@@ -1,7 +1,7 @@
 module Vcloud
   module Tools
     module Tester
-      VERSION = "2.0.0"
+      VERSION = "2.1.0"
     end
   end
 end

--- a/vcloud-tools-tester.gemspec
+++ b/vcloud-tools-tester.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.49.1'
   spec.add_development_dependency 'simplecov', '~> 0.14.1'
 
-  spec.add_runtime_dependency 'fog', '~> 1.36.0'
+  spec.add_runtime_dependency 'fog', '~> 1.40.0'
   spec.add_runtime_dependency 'vcloud-core'
   spec.add_runtime_dependency 'nokogiri', '~> 1.6.8.1'
 end

--- a/vcloud-tools-tester.gemspec
+++ b/vcloud-tools-tester.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.2.2'
 
   spec.add_development_dependency 'gem_publisher', '1.2.0'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
 - Update supported Ruby versions
 - Upgrade fog
 - Various bugfixes 

This module needs to be updated before we can update vcloud-core and other components, as vcloud-core depends on this module for testing, and so the fog versions must be the same in upgrades.

Story: https://trello.com/c/0uDbDpkt/574-update-dependencies-on-vcloud-tools