### PR TITLE
Put gem publishing logic into Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node {
 
     if (env.BRANCH_NAME == "master") {
       stage("Publish gem") {
-        sh('bundle exec rake publish_gem')
+        govuk.publishGem(repoName, env.BRANCH_NAME)
       }
     }
   } catch (e) {


### PR DESCRIPTION
When trying to publish gem I received an error about the hostkey being rejected. This was a known issue by GOV.UK developers when they moved over to the new CI environment, and they recommended using the Groovy library to do the publishing rather than the rake task.

Ref: https://github.com/alphagov/govuk-puppet/blob/3181d5dfcb85093aa9bf0a7f05049e6826f5e02e/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy#L586