### PR TITLE
Upgrade nokogiri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0 (2017-09-29)
+
+ - Upgrade Nokogiri to latest (1.8.1) due to vulnerability in libxml2.
+
 ## 2.1.0 (2017-06-22)
 
   - Upgrade to latest Fog

--- a/lib/vcloud/tools/tester/version.rb
+++ b/lib/vcloud/tools/tester/version.rb
@@ -1,7 +1,7 @@
 module Vcloud
   module Tools
     module Tester
-      VERSION = "2.1.0"
+      VERSION = "2.2.0"
     end
   end
 end

--- a/vcloud-tools-tester.gemspec
+++ b/vcloud-tools-tester.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'fog', '~> 1.40.0'
   spec.add_runtime_dependency 'vcloud-core'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.6.8.1'
+  spec.add_runtime_dependency 'nokogiri', '~> 1.8.1'
 end


### PR DESCRIPTION
There was a vulnerability in libxml2 which is resolved by updating to the latest version of nokogiri:

https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-20432

Release this as a new minor version due to the version bump of this dependency.